### PR TITLE
Fix deprecated setup cfg format

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
On top of our other changes, fix the deprecated setup cfg format. Switching `setup.cfg` to use the new format `_` instead of `-`, this currently [blocks upgrading ](https://github.com/headway/headway/pull/25449)to `3.11` 
```
error: The build backend returned an error
  Caused by: Call to `setuptools.build_meta:__legacy__.prepare_metadata_for_build_wheel` failed (exit status: 1)
[stderr]
    raise InvalidConfigError(
setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.

hint: This usually indicates a problem with the package or the build environment.
make: *** [compile-requirements] Error 2
(venv) 
```
